### PR TITLE
Bumped REST Assured schema validator to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.3.1</version>
+            <version>2.4.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Switching to the latest version also brings a fairly recent version of fge's JSON validator.

Build passes without issue after the upgrade.
