### PR TITLE
Avoid casting byte[] to String

### DIFF
--- a/src/main/java/guru/nidi/ramltester/restassured/RestAssuredRamlRequest.java
+++ b/src/main/java/guru/nidi/ramltester/restassured/RestAssuredRamlRequest.java
@@ -41,8 +41,13 @@ class RestAssuredRamlRequest extends RestAssuredRamlMessage implements RamlReque
 
     @Override
     public byte[] getContent() {
-        final String body = requestSpec.getBody();
-        return body == null ? null : body.getBytes();
+        final Object body = requestSpec.getBody();
+
+        if (body instanceof String) {
+            return ((String) body).getBytes();
+        }
+
+        return (byte[]) body;
     }
 
     @Override


### PR DESCRIPTION
From https://www.ietf.org/rfc/rfc2616.txt

> If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream".