### PR TITLE
Update raml-parser version to 0.8.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.raml</groupId>
             <artifactId>raml-parser</artifactId>
-            <version>0.8.17</version>
+            <version>0.8.21</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
@nidi3 
This PR just updates the raml-parser version.

Note that raml-parser version 0.8.17 depends on [json-schema-validator](https://github.com/java-json-tools/json-schema-validator) version 2.2.6 and version 0.8.21 depends on version 2.2.8.

2.2.8 and 2.2.6 are not binary compatible due to [a final class being changed to an interface](https://github.com/java-json-tools/json-schema-validator/commit/41f22fbbf94639230305346db93526f3bbb04c76).

If you get a chance to review this PR and it ends up getting merged in, then I'd appreciate it if you were able to cut a new version of raml-tester with this change.